### PR TITLE
fix: AutomationSettingsPanel UI 문구 실제 구조에 맞게 수정

### DIFF
--- a/src/components/automation/AutomationSettingsPanel.jsx
+++ b/src/components/automation/AutomationSettingsPanel.jsx
@@ -196,7 +196,7 @@ export function AutomationSettingsPanel() {
                         자동 매매 봇 설정
                     </h2>
                     <p className="text-[#858585] text-sm mt-1">
-                        Git Action 봇이 실행할 매매 시나리오를 관리합니다. (Supabase 저장)
+                        HuggingFace 서버 스케줄러(APScheduler)가 실행할 매매 설정을 관리합니다. (Supabase 저장)
                     </p>
                 </div>
             </div>

--- a/src/test/AutomationSettingsPanel.text.test.js
+++ b/src/test/AutomationSettingsPanel.text.test.js
@@ -1,0 +1,29 @@
+/**
+ * Issue #7: AutomationSettingsPanel UI 문구 정리
+ * - 'Git Action 봇' 문구 제거 확인
+ * - 실제 동작 방식(HuggingFace APScheduler)이 반영된 문구 확인
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const componentSource = readFileSync(
+    resolve(__dirname, '../components/automation/AutomationSettingsPanel.jsx'),
+    'utf-8'
+)
+
+describe('AutomationSettingsPanel UI 문구', () => {
+    it('"Git Action 봇" 문구가 없다', () => {
+        expect(componentSource).not.toContain('Git Action 봇')
+    })
+
+    it('"HuggingFace" 또는 "APScheduler" 문구가 포함된다', () => {
+        const hasHuggingFace = componentSource.includes('HuggingFace')
+        const hasAPScheduler = componentSource.includes('APScheduler')
+        expect(hasHuggingFace || hasAPScheduler).toBe(true)
+    })
+
+    it('"Supabase 저장" 안내 문구가 유지된다', () => {
+        expect(componentSource).toContain('Supabase 저장')
+    })
+})


### PR DESCRIPTION
## Summary
- 'Git Action 봇이 실행할 매매 시나리오를 관리합니다.' → 실제 동작(HuggingFace APScheduler) 반영 문구로 수정

## Test plan
- [x] "Git Action 봇" 문구 미포함 확인
- [x] "HuggingFace" 또는 "APScheduler" 문구 포함 확인
- [x] "Supabase 저장" 안내 유지 확인

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)