### PR TITLE
fix: FinancialQAPanel useMemo hist1d 의존성 전체 배열로 수정 (#21)

### DIFF
--- a/src/components/FinancialQAPanel.jsx
+++ b/src/components/FinancialQAPanel.jsx
@@ -197,7 +197,7 @@ export function FinancialQAPanel() {
     // 시장 컨텍스트를 메모이제이션
     const marketContext = useMemo(
         () => buildMarketContext(ticker, hist1d, simul, selectedResult, autoPredictions),
-        [ticker, hist1d?.length, selectedResult, simul, autoPredictions]
+        [ticker, hist1d, selectedResult, simul, autoPredictions]
     )
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- `FinancialQAPanel.jsx` L200 useMemo 의존성 배열에서 `hist1d?.length` → `hist1d` 전체로 변경
- 배열 내용이 바뀌어도 length가 같으면 재계산 안 되는 버그 수정

## Test plan
- [x] `src/test/financialQAPanel.deps.test.js` 5개 테스트 통과

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)