### PR TITLE
fix: api.js chart.result 옵셔널 체이닝 추가 (#23)

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -63,7 +63,7 @@ export async function fetchStockData(ticker, interval = '1d', range = '365d', in
     }
 
     const json = await response.json();
-    const result = json.chart.result[0];
+    const result = json?.chart?.result?.[0];
 
     if (!result) {
         throw new Error("No data found");

--- a/src/test/api.optionalChaining.test.js
+++ b/src/test/api.optionalChaining.test.js
@@ -1,0 +1,38 @@
+/**
+ * Issue #23: api.js chart.result 옵셔널 체이닝 없이 접근
+ * - json.chart가 null/undefined일 때 TypeError 방지 검증
+ * - json.chart.result가 빈 배열일 때 undefined 반환 검증
+ */
+import { describe, it, expect } from 'vitest'
+
+// api.js의 result 추출 로직을 그대로 재현
+const extractResult = (json) => json?.chart?.result?.[0]
+
+describe('api.js chart.result 옵셔널 체이닝', () => {
+    it('정상 응답에서 result[0]를 반환한다', () => {
+        const json = { chart: { result: [{ timestamp: [1, 2, 3] }] } }
+        expect(extractResult(json)).toEqual({ timestamp: [1, 2, 3] })
+    })
+
+    it('json이 null이면 undefined를 반환한다 (TypeError 없음)', () => {
+        expect(() => extractResult(null)).not.toThrow()
+        expect(extractResult(null)).toBeUndefined()
+    })
+
+    it('json.chart가 없으면 undefined를 반환한다', () => {
+        const json = { chart: null }
+        expect(() => extractResult(json)).not.toThrow()
+        expect(extractResult(json)).toBeUndefined()
+    })
+
+    it('json.chart.result가 빈 배열이면 undefined를 반환한다', () => {
+        const json = { chart: { result: [] } }
+        expect(extractResult(json)).toBeUndefined()
+    })
+
+    it('json.chart.result가 null이면 undefined를 반환한다', () => {
+        const json = { chart: { result: null } }
+        expect(() => extractResult(json)).not.toThrow()
+        expect(extractResult(json)).toBeUndefined()
+    })
+})


### PR DESCRIPTION
## Summary
- `api.js` L66 `json.chart.result[0]` → `json?.chart?.result?.[0]` 옵셔널 체이닝 적용
- Yahoo Finance API가 오류 응답 시 TypeError 방지

## Test plan
- [x] `src/test/api.optionalChaining.test.js` 5개 테스트 통과

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)