### PR TITLE
feat: 웹 뉴스 서비스 UI 구현 (#67 #68 #69 #70)

### DIFF
--- a/src/components/GlobalNewsPanel.jsx
+++ b/src/components/GlobalNewsPanel.jsx
@@ -1,0 +1,442 @@
+/**
+ * GlobalNewsPanel — 날짜별 뉴스 목록 + 상세 패널
+ * Issue #67: 날짜 선택 + 뉴스 카드 목록
+ * Issue #68: 뉴스 상세 패널 (주식 영향도 표시)
+ */
+import { useEffect, useState, useCallback } from 'react'
+import { format } from 'date-fns'
+import { useStore } from '@/store/useStore'
+import { fetchNewsByDate } from '@/lib/newsApi'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Progress } from '@/components/ui/progress'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover'
+import { Calendar } from '@/components/ui/calendar'
+import {
+    Newspaper,
+    CalendarIcon,
+    ExternalLink,
+    X,
+    TrendingUp,
+    TrendingDown,
+    Minus,
+    ChevronRight,
+} from 'lucide-react'
+
+// ─── KST 오늘 날짜를 Date 객체로 반환 ───────────────────────────────────────
+function getTodayKST() {
+    const now = new Date()
+    const kstOffset = 9 * 60 * 60 * 1000
+    return new Date(now.getTime() + kstOffset)
+}
+
+// ─── 충격 레벨 Badge 색상 ──────────────────────────────────────────────────
+function ImpactBadge({ level }) {
+    const map = {
+        high: { label: '높음', className: 'bg-red-900/50 text-red-300 border-red-700' },
+        medium: { label: '중간', className: 'bg-yellow-900/50 text-yellow-300 border-yellow-700' },
+        low: { label: '낮음', className: 'bg-green-900/50 text-green-300 border-green-700' },
+    }
+    const info = map[level] || { label: level || '-', className: 'bg-[#3c3c3c] text-[#888888]' }
+    return (
+        <Badge variant="outline" className={`text-xs shrink-0 ${info.className}`}>
+            {info.label}
+        </Badge>
+    )
+}
+
+// ─── 방향 아이콘 ───────────────────────────────────────────────────────────
+function DirectionIcon({ direction }) {
+    if (direction === 'bullish') return <TrendingUp className="w-4 h-4 text-green-400 shrink-0" />
+    if (direction === 'bearish') return <TrendingDown className="w-4 h-4 text-red-400 shrink-0" />
+    return <Minus className="w-4 h-4 text-[#888888] shrink-0" />
+}
+
+// ─── 시장 Badge ───────────────────────────────────────────────────────────
+function MarketBadge({ market }) {
+    const map = {
+        US: 'bg-blue-900/50 text-blue-300 border-blue-700',
+        KOSPI: 'bg-purple-900/50 text-purple-300 border-purple-700',
+        KOSDAQ: 'bg-indigo-900/50 text-indigo-300 border-indigo-700',
+        CRYPTO: 'bg-orange-900/50 text-orange-300 border-orange-700',
+    }
+    return (
+        <Badge variant="outline" className={`text-xs ${map[market] || 'bg-[#3c3c3c] text-[#888888]'}`}>
+            {market}
+        </Badge>
+    )
+}
+
+// ─── 로딩 스켈레톤 ────────────────────────────────────────────────────────
+function NewsCardSkeleton() {
+    return (
+        <Card className="bg-[#252526] border-[#3c3c3c]">
+            <CardContent className="p-4 space-y-3">
+                <div className="flex items-start gap-3">
+                    <Skeleton className="h-5 w-16 bg-[#3c3c3c]" />
+                    <Skeleton className="h-5 flex-1 bg-[#3c3c3c]" />
+                </div>
+                <Skeleton className="h-4 w-3/4 bg-[#3c3c3c]" />
+                <Skeleton className="h-4 w-1/2 bg-[#3c3c3c]" />
+            </CardContent>
+        </Card>
+    )
+}
+
+// ─── 뉴스 상세 패널 (Issue #68) ───────────────────────────────────────────
+function NewsDetailPanel({ news, onClose }) {
+    const [marketFilter, setMarketFilter] = useState('전체')
+    const markets = ['전체', 'US', 'KOSPI', 'KOSDAQ', 'CRYPTO']
+
+    const stockImpacts = news.news_stock_impact || []
+    const filteredStocks =
+        marketFilter === '전체'
+            ? stockImpacts
+            : stockImpacts.filter(s => s.market === marketFilter)
+
+    return (
+        <div className="flex flex-col h-full bg-[#1e1e1e] border-l border-[#3c3c3c]">
+            {/* 헤더 */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-[#3c3c3c] shrink-0">
+                <h2 className="text-sm font-semibold text-[#e1e1e1] line-clamp-1 flex-1 mr-2">
+                    {news.title}
+                </h2>
+                <button
+                    onClick={onClose}
+                    className="text-[#888888] hover:text-[#cccccc] transition-colors"
+                    aria-label="닫기"
+                >
+                    <X className="w-5 h-5" />
+                </button>
+            </div>
+
+            <ScrollArea className="flex-1">
+                <div className="p-4 space-y-4">
+                    {/* 메타 정보 */}
+                    <div className="flex flex-wrap gap-2 items-center">
+                        <ImpactBadge level={news.impact_level} />
+                        <span className="text-xs text-[#888888]">{news.source}</span>
+                        {news.published_at && (
+                            <span className="text-xs text-[#888888]">
+                                {news.published_at.slice(0, 16).replace('T', ' ')}
+                            </span>
+                        )}
+                    </div>
+
+                    {/* 요약 */}
+                    {news.summary && (
+                        <p className="text-sm text-[#cccccc] leading-relaxed">{news.summary}</p>
+                    )}
+
+                    {/* 시장 영향 */}
+                    {news.market_impact && (
+                        <div className="p-3 rounded-lg bg-[#252526] border border-[#3c3c3c]">
+                            <p className="text-xs font-semibold text-[#9cdcfe] mb-1">시장 영향 분석</p>
+                            <p className="text-sm text-[#cccccc] leading-relaxed whitespace-pre-wrap">
+                                {news.market_impact}
+                            </p>
+                        </div>
+                    )}
+
+                    {/* 주식 영향 목록 */}
+                    {stockImpacts.length > 0 && (
+                        <div className="space-y-3">
+                            <p className="text-xs font-semibold text-[#9cdcfe]">
+                                종목별 영향 ({stockImpacts.length}개)
+                            </p>
+
+                            {/* 시장 필터 탭 */}
+                            <Tabs value={marketFilter} onValueChange={setMarketFilter}>
+                                <TabsList className="bg-[#252526] border border-[#3c3c3c] h-8 gap-0 p-0.5">
+                                    {markets.map(m => (
+                                        <TabsTrigger
+                                            key={m}
+                                            value={m}
+                                            className="text-xs px-2 h-7 data-[state=active]:bg-[#007acc] data-[state=active]:text-white text-[#888888]"
+                                        >
+                                            {m}
+                                        </TabsTrigger>
+                                    ))}
+                                </TabsList>
+
+                                <TabsContent value={marketFilter} className="mt-2 space-y-2">
+                                    {filteredStocks.length === 0 ? (
+                                        <p className="text-xs text-[#666666] py-2">해당 시장의 종목 영향 데이터가 없습니다.</p>
+                                    ) : (
+                                        filteredStocks.map((stock, idx) => (
+                                            <div
+                                                key={stock.id ?? idx}
+                                                className="p-3 rounded-lg bg-[#252526] border border-[#3c3c3c] space-y-2"
+                                            >
+                                                <div className="flex items-center gap-2 flex-wrap">
+                                                    <DirectionIcon direction={stock.direction} />
+                                                    <span className="text-sm font-semibold text-[#e1e1e1]">
+                                                        {stock.ticker}
+                                                    </span>
+                                                    {stock.name && (
+                                                        <span className="text-xs text-[#888888]">{stock.name}</span>
+                                                    )}
+                                                    {stock.market && <MarketBadge market={stock.market} />}
+                                                </div>
+
+                                                {stock.reason && (
+                                                    <p className="text-xs text-[#cccccc] leading-relaxed">
+                                                        {stock.reason}
+                                                    </p>
+                                                )}
+
+                                                {stock.confidence != null && (
+                                                    <div className="space-y-1">
+                                                        <div className="flex justify-between text-xs text-[#888888]">
+                                                            <span>신뢰도</span>
+                                                            <span>{Math.round(stock.confidence * 100)}%</span>
+                                                        </div>
+                                                        <Progress
+                                                            value={stock.confidence * 100}
+                                                            className="h-1.5 bg-[#3c3c3c]"
+                                                        />
+                                                    </div>
+                                                )}
+                                            </div>
+                                        ))
+                                    )}
+                                </TabsContent>
+                            </Tabs>
+                        </div>
+                    )}
+
+                    {/* 원문 보기 버튼 */}
+                    {news.url && (
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="w-full border-[#3c3c3c] text-[#cccccc] hover:bg-[#2d2d2d] hover:text-white"
+                            onClick={() => window.open(news.url, '_blank', 'noopener,noreferrer')}
+                        >
+                            <ExternalLink className="w-4 h-4 mr-2" />
+                            원문 보기
+                        </Button>
+                    )}
+                </div>
+            </ScrollArea>
+        </div>
+    )
+}
+
+// ─── 뉴스 카드 ─────────────────────────────────────────────────────────────
+function NewsCard({ news, isSelected, onClick }) {
+    return (
+        <Card
+            className={`bg-[#252526] border-[#3c3c3c] cursor-pointer transition-colors hover:border-[#007acc] ${
+                isSelected ? 'border-[#007acc] bg-[#1a2a3a]' : ''
+            }`}
+            onClick={onClick}
+        >
+            <CardContent className="p-4">
+                <div className="flex items-start gap-3">
+                    <div className="flex-1 min-w-0 space-y-1.5">
+                        {/* 제목 + 충격 레벨 */}
+                        <div className="flex items-start gap-2">
+                            <p className="text-sm font-medium text-[#e1e1e1] leading-snug flex-1 line-clamp-2">
+                                {news.title}
+                            </p>
+                            <ImpactBadge level={news.impact_level} />
+                        </div>
+
+                        {/* 시장 영향 요약 (truncated) */}
+                        {news.market_impact && (
+                            <p className="text-xs text-[#888888] line-clamp-2 leading-relaxed">
+                                {news.market_impact}
+                            </p>
+                        )}
+
+                        {/* 소스 + 시간 */}
+                        <div className="flex items-center gap-2 text-xs text-[#666666]">
+                            {news.source && <span>{news.source}</span>}
+                            {news.published_at && (
+                                <span>{news.published_at.slice(0, 16).replace('T', ' ')}</span>
+                            )}
+                            {news.news_stock_impact?.length > 0 && (
+                                <span className="ml-auto text-[#4fc3f7]">
+                                    종목 {news.news_stock_impact.length}개
+                                </span>
+                            )}
+                        </div>
+                    </div>
+                    <ChevronRight className="w-4 h-4 text-[#555555] shrink-0 mt-0.5" />
+                </div>
+            </CardContent>
+        </Card>
+    )
+}
+
+// ─── 메인 GlobalNewsPanel (Issue #67) ─────────────────────────────────────
+export function GlobalNewsPanel() {
+    const {
+        newsItems,
+        newsSelectedDate,
+        newsIsLoading,
+        newsError,
+        setNewsItems,
+        setNewsSelectedDate,
+        setNewsIsLoading,
+        setNewsError,
+    } = useStore()
+
+    const [selectedNews, setSelectedNews] = useState(null)
+    const [calendarOpen, setCalendarOpen] = useState(false)
+
+    // 날짜 문자열 → Date 객체 (캘린더용)
+    const todayKST = getTodayKST()
+    const selectedDateObj = newsSelectedDate
+        ? new Date(newsSelectedDate + 'T00:00:00')
+        : todayKST
+
+    const displayDate = newsSelectedDate || format(todayKST, 'yyyy-MM-dd')
+
+    const loadNews = useCallback(async (date) => {
+        setNewsIsLoading(true)
+        setNewsError(null)
+        setSelectedNews(null)
+        try {
+            const result = await fetchNewsByDate(date)
+            setNewsItems(result.items || [])
+        } catch (e) {
+            setNewsError(e.message)
+            setNewsItems([])
+        } finally {
+            setNewsIsLoading(false)
+        }
+    }, [setNewsIsLoading, setNewsError, setNewsItems])
+
+    // 마운트 시 및 날짜 변경 시 뉴스 로드
+    useEffect(() => {
+        loadNews(newsSelectedDate || undefined)
+    }, [newsSelectedDate]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    const handleDateSelect = (date) => {
+        if (!date) return
+        const formatted = format(date, 'yyyy-MM-dd')
+        setNewsSelectedDate(formatted)
+        setCalendarOpen(false)
+    }
+
+    return (
+        <div className="flex h-full overflow-hidden">
+            {/* 좌측 뉴스 목록 */}
+            <div className={`flex flex-col ${selectedNews ? 'w-1/2' : 'w-full'} transition-all duration-200`}>
+                {/* 툴바 */}
+                <div className="flex items-center gap-3 px-4 py-3 border-b border-[#3c3c3c] shrink-0 bg-[#252526]">
+                    <Newspaper className="w-5 h-5 text-[#007acc] shrink-0" />
+                    <h1 className="text-base font-semibold text-[#e1e1e1]">글로벌 뉴스</h1>
+
+                    <div className="ml-auto flex items-center gap-2">
+                        {/* 날짜 선택기 */}
+                        <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+                            <PopoverTrigger asChild>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="border-[#3c3c3c] bg-[#1e1e1e] text-[#cccccc] hover:bg-[#2d2d2d] hover:text-white gap-2"
+                                >
+                                    <CalendarIcon className="w-4 h-4" />
+                                    {displayDate}
+                                </Button>
+                            </PopoverTrigger>
+                            <PopoverContent
+                                className="w-auto p-0 bg-[#252526] border-[#3c3c3c]"
+                                align="end"
+                            >
+                                <Calendar
+                                    mode="single"
+                                    selected={selectedDateObj}
+                                    onSelect={handleDateSelect}
+                                    disabled={(date) => date > todayKST}
+                                    className="text-[#cccccc]"
+                                />
+                            </PopoverContent>
+                        </Popover>
+
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => loadNews(newsSelectedDate || undefined)}
+                            disabled={newsIsLoading}
+                            className="text-[#888888] hover:text-[#cccccc]"
+                        >
+                            새로고침
+                        </Button>
+                    </div>
+                </div>
+
+                {/* 뉴스 카운트 */}
+                {!newsIsLoading && !newsError && (
+                    <div className="px-4 py-2 text-xs text-[#666666] border-b border-[#3c3c3c] shrink-0">
+                        {displayDate} · {newsItems.length}개 뉴스
+                    </div>
+                )}
+
+                {/* 목록 */}
+                <ScrollArea className="flex-1 bg-[#1e1e1e]">
+                    <div className="p-4 space-y-3 pb-12">
+                        {newsIsLoading ? (
+                            // 로딩 스켈레톤
+                            Array.from({ length: 5 }).map((_, i) => (
+                                <NewsCardSkeleton key={i} />
+                            ))
+                        ) : newsError ? (
+                            // 에러 상태
+                            <div className="flex flex-col items-center justify-center py-20 text-[#888888]">
+                                <Newspaper className="w-12 h-12 mb-4 opacity-30" />
+                                <p className="text-sm">뉴스를 불러올 수 없습니다.</p>
+                                <p className="text-xs mt-1 text-[#555555]">{newsError}</p>
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    className="mt-4 border-[#3c3c3c] text-[#888888]"
+                                    onClick={() => loadNews(newsSelectedDate || undefined)}
+                                >
+                                    다시 시도
+                                </Button>
+                            </div>
+                        ) : newsItems.length === 0 ? (
+                            // 빈 상태
+                            <div className="flex flex-col items-center justify-center py-20 text-[#888888]">
+                                <Newspaper className="w-12 h-12 mb-4 opacity-30" />
+                                <p className="text-sm">해당 날짜의 뉴스가 없습니다.</p>
+                                <p className="text-xs mt-1 text-[#555555]">{displayDate}</p>
+                            </div>
+                        ) : (
+                            newsItems.map((item) => (
+                                <NewsCard
+                                    key={item.id}
+                                    news={item}
+                                    isSelected={selectedNews?.id === item.id}
+                                    onClick={() =>
+                                        setSelectedNews(prev =>
+                                            prev?.id === item.id ? null : item
+                                        )
+                                    }
+                                />
+                            ))
+                        )}
+                    </div>
+                </ScrollArea>
+            </div>
+
+            {/* 우측 상세 패널 (Issue #68) */}
+            {selectedNews && (
+                <div className="w-1/2 border-l border-[#3c3c3c]">
+                    <NewsDetailPanel
+                        news={selectedNews}
+                        onClose={() => setSelectedNews(null)}
+                    />
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/components/layout/EditorArea.jsx
+++ b/src/components/layout/EditorArea.jsx
@@ -23,6 +23,7 @@ const AnalysisPanel = lazy(() => import("../AnalysisPanel").then(m => ({ default
 const StockDiscussionPanel = lazy(() => import("../StockDiscussionPanel").then(m => ({ default: m.StockDiscussionPanel })))
 const OverviewPanel = lazy(() => import("../OverviewPanel").then(m => ({ default: m.OverviewPanel })))
 const NewsPanel = lazy(() => import("../NewsPanel").then(m => ({ default: m.NewsPanel })))
+const GlobalNewsPanel = lazy(() => import("../GlobalNewsPanel").then(m => ({ default: m.GlobalNewsPanel })))
 const FinancialQAPanel = lazy(() => import("../FinancialQAPanel").then(m => ({ default: m.FinancialQAPanel })))
 const PortfolioDashboard = lazy(() => import("../PortfolioDashboard").then(m => ({ default: m.PortfolioDashboard })))
 const EarningsImpactPanel = lazy(() => import("../EarningsImpactPanel").then(m => ({ default: m.EarningsImpactPanel })))
@@ -91,7 +92,7 @@ export function EditorArea() {
 
     const renderContent = () => {
         // 탭이 하나도 없으면 소개 화면 표시 (단, 티커와 무관한 독립 패널 모드는 제외)
-        const independentModes = ['docs', 'portfolio', 'analyze', 'deepLearning', 'automation']
+        const independentModes = ['docs', 'portfolio', 'analyze', 'deepLearning', 'automation', 'news']
         if ((!activeTickers || activeTickers.length === 0) && !independentModes.includes(viewMode)) {
             return <IntroScreen />
         }
@@ -101,8 +102,13 @@ export function EditorArea() {
             return <OverviewPanel />
         }
 
-        // News Mode
+        // News Mode — global backend news feed (ticker-independent)
         if (viewMode === 'news') {
+            return <GlobalNewsPanel />
+        }
+
+        // Stock News Mode — Yahoo Finance stock-specific news
+        if (viewMode === 'stockNews') {
             return <NewsPanel />
         }
 

--- a/src/components/ui/skeleton.jsx
+++ b/src/components/ui/skeleton.jsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }) {
+    return (
+        <div
+            className={cn("animate-pulse rounded-md bg-muted", className)}
+            {...props}
+        />
+    )
+}
+
+export { Skeleton }

--- a/src/lib/geminiKeyManager.js
+++ b/src/lib/geminiKeyManager.js
@@ -1,0 +1,67 @@
+/**
+ * Gemini API 멀티 키 로드 밸런서
+ * VITE_GEMINI_API_KEY 환경 변수에서 쉼표로 구분된 여러 키를 파싱하여
+ * 라운드 로빈 방식으로 분배합니다.
+ */
+
+// 키 목록 파싱 (쉼표 구분, 공백 제거)
+const rawKeys = (import.meta.env.VITE_GEMINI_API_KEY || '').split(',').map(k => k.trim()).filter(Boolean)
+
+// 각 키의 상태 관리 { key: string, rateLimitedUntil: number }
+const keyStates = rawKeys.map(key => ({ key, rateLimitedUntil: 0 }))
+
+// 라운드 로빈 인덱스 (모듈 레벨 상태)
+let currentIndex = 0
+
+/**
+ * 다음 사용 가능한 Gemini API 키를 반환합니다.
+ * Rate-limited 키는 냉각 시간이 지날 때까지 건너뜁니다.
+ * 사용 가능한 키가 없으면 null을 반환합니다.
+ *
+ * @returns {string|null} API 키 또는 null
+ */
+export function getNextKey() {
+    if (keyStates.length === 0) return null
+
+    const now = Date.now()
+    const total = keyStates.length
+
+    // 한 바퀴를 돌면서 사용 가능한 키 탐색
+    for (let i = 0; i < total; i++) {
+        const idx = (currentIndex + i) % total
+        const state = keyStates[idx]
+
+        if (state.rateLimitedUntil <= now) {
+            // 다음 호출을 위해 인덱스를 전진
+            currentIndex = (idx + 1) % total
+            return state.key
+        }
+    }
+
+    // 모든 키가 Rate-limited 상태
+    console.warn('[GeminiKeyManager] 모든 Gemini API 키가 rate-limited 상태입니다.')
+    return null
+}
+
+/**
+ * 특정 키를 일정 시간 동안 Rate-limited 상태로 표시합니다.
+ * 429 응답을 받았을 때 호출합니다.
+ *
+ * @param {string} key - Rate-limited 상태로 표시할 API 키
+ * @param {number} [cooldownMs=60000] - 냉각 시간 (밀리초, 기본 60초)
+ */
+export function markRateLimited(key, cooldownMs = 60000) {
+    const state = keyStates.find(s => s.key === key)
+    if (state) {
+        state.rateLimitedUntil = Date.now() + cooldownMs
+        console.warn(`[GeminiKeyManager] 키 ...${key.slice(-6)} rate-limited. ${cooldownMs / 1000}초 후 재사용 가능.`)
+    }
+}
+
+/**
+ * 현재 등록된 키 수를 반환합니다.
+ * @returns {number}
+ */
+export function getKeyCount() {
+    return keyStates.length
+}

--- a/src/lib/newsApi.js
+++ b/src/lib/newsApi.js
@@ -1,0 +1,71 @@
+/**
+ * 백엔드 뉴스 API 클라이언트
+ * VITE_BACKEND_URL 환경 변수를 기반으로 백엔드에 요청합니다.
+ */
+import { format } from 'date-fns'
+
+const BACKEND_URL =
+    import.meta.env.VITE_BACKEND_URL ||
+    'https://inpiniti-bitcoin-ai-backend.hf.space'
+
+/**
+ * KST 기준 오늘 날짜를 'YYYY-MM-DD' 형식으로 반환합니다.
+ * @returns {string}
+ */
+function getTodayKST() {
+    // KST = UTC+9
+    const now = new Date()
+    const kstOffset = 9 * 60 * 60 * 1000
+    const kstDate = new Date(now.getTime() + kstOffset)
+    return format(kstDate, 'yyyy-MM-dd')
+}
+
+/**
+ * 특정 날짜의 뉴스 목록을 조회합니다.
+ *
+ * @param {string} [date] - 'YYYY-MM-DD' 형식의 날짜. 미지정 시 KST 기준 오늘.
+ * @returns {Promise<{ date: string, count: number, items: Array }>}
+ */
+export async function fetchNewsByDate(date) {
+    const targetDate = date || getTodayKST()
+    const url = `${BACKEND_URL}/news?date=${encodeURIComponent(targetDate)}`
+
+    const response = await fetch(url)
+    if (!response.ok) {
+        throw new Error(`뉴스 조회 실패 (${response.status}): ${response.statusText}`)
+    }
+
+    return response.json()
+}
+
+/**
+ * 뉴스 크롤링을 트리거합니다.
+ *
+ * @returns {Promise<Object>} 서버 응답
+ */
+export async function triggerNewsCrawl() {
+    const url = `${BACKEND_URL}/news/crawl`
+
+    const response = await fetch(url, { method: 'POST' })
+    if (!response.ok) {
+        throw new Error(`뉴스 크롤링 실패 (${response.status}): ${response.statusText}`)
+    }
+
+    return response.json()
+}
+
+/**
+ * 뉴스 AI 분석을 트리거합니다.
+ *
+ * @returns {Promise<Object>} 서버 응답
+ */
+export async function triggerNewsAnalyze() {
+    const url = `${BACKEND_URL}/news/analyze`
+
+    const response = await fetch(url, { method: 'POST' })
+    if (!response.ok) {
+        throw new Error(`뉴스 분석 실패 (${response.status}): ${response.statusText}`)
+    }
+
+    return response.json()
+}

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -255,6 +255,16 @@ export const useStore = create(
                 selectedDoc: null, // key of DOCS_DATA
                 setSelectedDoc: (docKey) => set({ selectedDoc: docKey }),
 
+                // News State (#67)
+                newsItems: [],
+                newsSelectedDate: null, // null = today (KST)
+                newsIsLoading: false,
+                newsError: null,
+                setNewsSelectedDate: (date) => set({ newsSelectedDate: date }),
+                setNewsItems: (items) => set({ newsItems: items }),
+                setNewsIsLoading: (loading) => set({ newsIsLoading: loading }),
+                setNewsError: (error) => set({ newsError: error }),
+
                 // Actions
                 setViewMode: (viewMode) => set({ viewMode }),
                 setGlobalError: (error) => set({ globalError: error }),


### PR DESCRIPTION
## Summary
- **#69** `src/lib/geminiKeyManager.js` — Gemini 다중 키 라운드로빈 + 429 rate limit 스킵
- **#70** `src/lib/newsApi.js` — 백엔드 뉴스 API 클라이언트 (날짜별 조회)
- **#67** `src/components/GlobalNewsPanel.jsx` — 날짜 선택 + 뉴스 카드 목록 (impact 배지, skeleton)
- **#68** `NewsDetailPanel` (GlobalNewsPanel 내) — 영향 종목 목록, 방향 아이콘, 신뢰도 Progress, 시장 필터 탭

## Changes
- `src/store/useStore.js` — 뉴스 상태 추가 (newsItems, selectedDate, isLoading, error)
- `src/components/layout/EditorArea.jsx` — news 뷰모드 추가
- `src/components/ui/skeleton.jsx` — Skeleton 컴포넌트 추가

close #67
close #68
close #69
close #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)